### PR TITLE
Make amplio2 spec files valid format

### DIFF
--- a/freeciv/freeciv/data/amplio2/animals.spec
+++ b/freeciv/freeciv/data/amplio2/animals.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file:
-options = "+Freeciv-2.6-spec"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio2/bases.spec
+++ b/freeciv/freeciv/data/amplio2/bases.spec
@@ -50,7 +50,7 @@ tiles = { "row", "column", "tag"
  2,  5, "base.castle_bg"
  2,  6, "base.bunker_mg"
 ;[HH]
-  not used in FCW, had to save space to prevent a clipping bug
+;  not used in FCW, had to save space to prevent a clipping bug
  0,  2, "cd.occupied",
       "city.european_occupied_0",
       "city.classical_occupied_0",

--- a/freeciv/freeciv/data/amplio2/canal.spec
+++ b/freeciv/freeciv/data/amplio2/canal.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file: 
-options = "+Freeciv-spec-Devel-2015-Mar-25"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio2/swords.spec
+++ b/freeciv/freeciv/data/amplio2/swords.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file: 
-options = "+Freeciv-spec-Devel-2015-Mar-25"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 

--- a/freeciv/freeciv/data/amplio2/units_oversize.spec
+++ b/freeciv/freeciv/data/amplio2/units_oversize.spec
@@ -2,7 +2,7 @@
 [spec]
 
 ; Format and options of this spec file: 
-options = "+Freeciv-spec-Devel-2015-Mar-25"
+options = "+Freeciv-spec-Devel-2019-Jul-03"
 
 [info]
 


### PR DESCRIPTION
Using valid specfile format makes it possible to load the tileset to desktop client.