### PR TITLE
Install OS provided lua, if available

### DIFF
--- a/scripts/install/deb.sh
+++ b/scripts/install/deb.sh
@@ -76,6 +76,12 @@ else
   INSTALLED_TOMCAT=N
 fi
 
+# Install lua-5.4, if available. Otherwise it will be built from the copy
+# included with the server.
+if apt-cache -qq show liblua5.4-dev &> /dev/null; then
+  dependencies="${dependencies} liblua5.4-dev"
+fi
+
 if [ "${FCW_INSTALL_MODE}" = TEST ]; then
   dependencies="${dependencies} xvfb"
 fi


### PR DESCRIPTION
Server build will automatically use system provided lua when it's
available. That has two advantages.

1) We gain e.g. security updates to lua from OS vendor automatically

2) It makes it possible to build server with clang.
   Lua does not build with clang, so when it's built as part of
   the server, lua prevents building the server with clang.