### PR TITLE
CI: Run github actions on ubuntu-20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   normal:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
       - name: check out Freeciv-web
         uses: actions/checkout@v2


### PR DESCRIPTION
Switch Continuous Integration (github actions) to run on ubuntu-20.04 setup.

I have had no github setup to test this before making this Pull Request. When github actions get triggered by creation of this Pull Request, it will be the first test of this patch. Pay attention to results.